### PR TITLE
Add null check for direct.image and agency.image

### DIFF
--- a/src/remotes/index.ts
+++ b/src/remotes/index.ts
@@ -32,7 +32,10 @@ export async function fetchHouses(candidate: Filter): Promise<House[]> {
 
   const { direct = { image: [] }, agency = { image: [] } } = data.houses;
 
-  const houses = [...direct.image, ...agency.image].filter(h => {
+  const houses = [
+    ...(direct.image ? direct.image : []), 
+    ...(agency.image ? agency.image : [])
+  ].filter(h => {
     return (
       (candidate.shouldIncludeHalfUndergrounds ||
         !h.info.is_half_underground) &&


### PR DESCRIPTION
`direct.image`와 `agency.image` 로 `houses`를 만들 때, 핫픽스로 간단한 null check를 추가했습니다.

This fixes #1